### PR TITLE
Fixes the do-update-set! helper function

### DIFF
--- a/src/honeysql_postgres/helpers.clj
+++ b/src/honeysql_postgres/helpers.clj
@@ -11,7 +11,7 @@
 (defhelper do-update-set [m args]
   (assoc m :do-update-set (collify args)))
 
-(defhelper db-update-set! [m args]
+(defhelper do-update-set! [m args]
   (assoc m :do-update-set! args))
 
 (defhelper on-conflict [m args]


### PR DESCRIPTION
- Fixes the typo in the `do-update-set!` function
- Adds the required test and fixes faulty tests
- Adds `do-update-set!` to README, removes incorrect examples.
