### PR TITLE
Add insert into with alias

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nilenso/honeysql-postgres "0.2.2-SNAPSHOT"
+(defproject nilenso/honeysql-postgres "0.2.2"
   :description "PostgreSQL extension for honeysql"
   :url "https://github.com/nilenso/honeysql-postgres"
   :license {:name "Eclipse Public License"

--- a/src/honeysql_postgres/format.clj
+++ b/src/honeysql_postgres/format.clj
@@ -12,6 +12,7 @@
    :add-column 30
    :drop-column 40
    :create-view 40
+   :insert-into-as 60
    :over 55
    :partition-by 165
    :window 195
@@ -186,5 +187,8 @@
   (str "RENAME TO " (-> newname
                         get-first
                         to-sql)))
+
+(defmethod format-clause :insert-into-as [[_ [table-name table-alias]] _]
+  (str  "INSERT INTO " (to-sql table-name) " AS " (to-sql table-alias)))
 
 (override-default-clause-priority)

--- a/src/honeysql_postgres/helpers.clj
+++ b/src/honeysql_postgres/helpers.clj
@@ -63,3 +63,6 @@
 
 (defhelper rename-table [m fields]
   (assoc m :rename-table (collify fields)))
+
+(defhelper insert-into-as [m fields]
+  (assoc m :insert-into-as (collify fields)))

--- a/test/honeysql_postgres/postgres_test.clj
+++ b/test/honeysql_postgres/postgres_test.clj
@@ -154,3 +154,15 @@
            (-> (alter-table :employees)
                (rename-table :managers)
                sql/format)))))
+
+(deftest insert-into-with-alias
+  (testing "insert into with alias"
+    (is (= ["INSERT INTO distributors AS d (did, dname) VALUES (5, ?), (6, ?) ON CONFLICT (did) DO UPDATE SET dname = EXCLUDED.dname WHERE d.zipcode <> ? RETURNING d.*" "Gizmo Transglobal" "Associated Computing, Inc" "21201"]
+           (-> (insert-into-as :distributors :d)
+               (values [{:did 5 :dname "Gizmo Transglobal"}
+                        {:did 6 :dname "Associated Computing, Inc"}])
+               (upsert (-> (on-conflict :did)
+                           (do-update-set :dname)
+                           (where [:<> :d.zipcode "21201"])))
+               (returning :d.*)
+               sql/format)))))


### PR DESCRIPTION
Adds `insert-into-as` which allows table name to be aliased in insert statements.
