### PR TITLE
Allow WHERE in multiple positions in do-update-set

### DIFF
--- a/src/honeysql_postgres/format.clj
+++ b/src/honeysql_postgres/format.clj
@@ -105,9 +105,12 @@
                                       (str (to-sql k) " = " (to-sql v))))))
 
 (defmethod format-clause :do-update-set [[_ values] _]
-  (str "DO UPDATE SET "
-       (comma-join (map #(str (to-sql %) " = EXCLUDED." (to-sql %))
-                        values))))
+  (let [fields (or (:fields values) values)
+        where  (:where values)]
+    (str "DO UPDATE SET "
+      (comma-join (map #(str (to-sql %) " = EXCLUDED." (to-sql %)) fields))
+      (when where
+        (str " WHERE " (format-predicate* where))))))
 
 (defn- format-upsert-clause [upsert]
   (let [ks (keys upsert)]

--- a/test/honeysql_postgres/postgres_test.clj
+++ b/test/honeysql_postgres/postgres_test.clj
@@ -41,6 +41,18 @@
                (do-update-set! [:dname "EXCLUDED.dname || ' (formerly ' || d.dname || ')'"])
                sql/format)))))
 
+
+(deftest upsert-where-test
+  (is (= ["INSERT INTO user (phone, name) VALUES (?, ?) ON CONFLICT (phone) WHERE phone IS NOT NULL DO UPDATE SET phone = EXCLUDED.phone, name = EXCLUDED.name WHERE user.active = FALSE" "5555555" "John"]
+         (sql/format
+           {:insert-into :user
+            :values      [{:phone "5555555" :name "John"}]
+            :upsert      {:on-conflict   [:phone]
+                          :where         [:<> :phone nil]
+                          :do-update-set {:fields [:phone :name]
+                                          :where  [:= :user.active false]}}}))))
+
+
 (deftest returning-test
   (testing "returning clause in sql generation for postgresql"
     (is (= ["DELETE FROM distributors WHERE did > 10 RETURNING *"]


### PR DESCRIPTION
As per postgres [upsert documentation](https://www.postgresql.org/docs/9.5/static/sql-insert.html) the "WHERE" clause can be used in two context:

- as an index predicate
- as update condition

Current syntax only allows you to specify only one of these but not both (which one is used depends on the keys order in a map).

This change extends `do-update-set` syntax so that it can be used for queries with WHERE in both context simultaneously.