### PR TITLE
Introduce :primary-key

### DIFF
--- a/src/honeysql_postgres/format.clj
+++ b/src/honeysql_postgres/format.clj
@@ -77,6 +77,9 @@
 (defmethod fn-handler "default" [_ value]
   (str "DEFAULT " (to-sql value)))
 
+(defmethod fn-handler "primary-key" [_ & args]
+  (str "PRIMARY KEY" (util/comma-join-args args)))
+
 (defmethod fn-handler "nextval" [_ value]
   (str "nextval('" (to-sql value) "')"))
 


### PR DESCRIPTION
The patch makes the following working: `(honeysql.core/call :primary-key)`.