### PR TITLE
Add if-not-exist option to create-table

### DIFF
--- a/src/honeysql_postgres/format.cljc
+++ b/src/honeysql_postgres/format.cljc
@@ -125,10 +125,12 @@
                           util/get-first
                           sqlf/to-sql) " AS"))
 
-(defmethod format-clause :create-table [[_ tablename] _]
-  (str "CREATE TABLE " (-> tablename
-                           util/get-first
-                           sqlf/to-sql)))
+(defmethod format-clause :create-table [[_ [tablename if-not-exists]] _]
+  (str "CREATE TABLE "
+       (when if-not-exists "IF NOT EXISTS ")
+       (-> tablename
+           util/get-first
+           sqlf/to-sql)))
 
 (defmethod format-clause :with-columns [[_ columns] _]
   (sqlf/paren-wrap (->> columns

--- a/test/honeysql_postgres/postgres_test.cljc
+++ b/test/honeysql_postgres/postgres_test.cljc
@@ -184,3 +184,9 @@
                            (where [:<> :d.zipcode "21201"])))
                (returning :d.*)
                sql/format)))))
+
+(deftest create-table-if-not-exists
+  (testing "create a table if not exists"
+    (is (= ["CREATE TABLE IF NOT EXISTS tablename"]
+           (-> (create-table :tablename :if-not-exists)
+               sql/format)))))


### PR DESCRIPTION
This enables the following syntax (create-table :table :if-not-exists) for
CREATE TABLE IF NOT EXISTS table