### PR TITLE
Add package.json for npm publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@honeysql/honeysql-postgres",
+  "version": "0.2.3",
+  "license": "EPL-1.0",
+  "homepage": "https://github.com/nilenso/honeysql-postgres",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/nilenso/honeysql-postgres"
+  },
+  "contributors": [
+    {
+      "name": "Unnikrishnan",
+      "email": "krish8664@gmail.com",
+      "url": "http://unnikrishnan.in"
+    },
+    {
+      "name": "Andrea Richiardi",
+      "email": "a.richiardi.work@gmail.com",
+      "url": "https://andrearichiardi.com"
+    },
+    {
+      "name": "Igor Bondarenko"
+    }
+  ],
+  "files": [
+    "src/*"
+  ],
+  "directories": {
+    "lib": "src"
+  }
+}


### PR DESCRIPTION
This PR adds the `package.json` necessary for publishing on `npm`.

The package name will be `@honeysql/honeysql-postgres`.

As a reminder, to check the content of the published tarball:

```
npm pack
honeysql-honeysql-postgres-0.2.3.tgz
$ tar -vtf honeysql-honeysql-postgres-0.2.3.tgz
-rw-rw-r-- 0/0             646 2018-05-15 11:12 package/package.json
-rw-rw-r-- 0/0             650 2017-11-05 12:29 package/CHANGELOG.md
-rw-rw-r-- 0/0           11218 2017-11-05 12:29 package/LICENSE
-rw-rw-r-- 0/0            7128 2017-11-05 12:29 package/README.md
-rw-rw-r-- 0/0            6402 2018-05-15 10:58
package/src/honeysql_postgres/format.cljc
-rw-rw-r-- 0/0            1860 2018-05-07 10:20
package/src/honeysql_postgres/helpers.cljc
-rw-rw-r-- 0/0            1094 2018-05-07 10:20 package/src/honeysql_postgres/util.cljc
```

And then to publish:

```
npm login   # ask @arichiardi to be added to the team after having created a user on npm
npm publish
```