### PR TITLE
[Fix #24] Add :if-exists clause to :drop-table

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,0 +1,1 @@
+{:deps {honeysql {:mvn/version "0.9.4" :exclusions [org.clojure/clojurescript]}}}

--- a/project.clj
+++ b/project.clj
@@ -3,8 +3,11 @@
   :url "https://github.com/nilenso/honeysql-postgres"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.8.0"]
-                 [honeysql "0.9.2"]]
+  ;; read dependencies from deps.edn
+  :plugins [[lein-tools-deps "0.4.1"]]
+  :middleware [lein-tools-deps.plugin/resolve-dependencies-with-deps-edn]
+  :lein-tools-deps/config {:config-files [:install :user :project]}
+
   :tach {:test-runner-ns 'honeysql-postgres.postgres-test
          :source-paths ["src" "test"]}
   :profiles {:dev {:plugins [[lein-tach "0.4.0"]]}})

--- a/src/honeysql_postgres/format.cljc
+++ b/src/honeysql_postgres/format.cljc
@@ -138,10 +138,16 @@
                         (map #(sqlf/space-join (map sqlf/to-sql %)))
                         sqlf/comma-join)))
 
-(defmethod format-clause :drop-table [[_ tables] _]
-  (str "DROP TABLE " (->> tables
-                          (map sqlf/to-sql)
-                          sqlf/comma-join)))
+(defmethod format-clause :drop-table [[_ params] _]
+  (let [[if-exists & others] params
+        tables (if-not (= :if-exists if-exists)
+                 params
+                 others)]
+    (str "DROP TABLE "
+         (when (= :if-exists if-exists) "IF EXISTS ")
+         (->> tables
+              (map sqlf/to-sql)
+              sqlf/comma-join))))
 
 (defn- format-over-clause [exp]
   (str

--- a/test/honeysql_postgres/postgres_test.cljc
+++ b/test/honeysql_postgres/postgres_test.cljc
@@ -190,3 +190,9 @@
     (is (= ["CREATE TABLE IF NOT EXISTS tablename"]
            (-> (create-table :tablename :if-not-exists)
                sql/format)))))
+
+(deftest drop-table-if-exists
+  (testing "drop a table if it exists"
+    (is (= ["DROP TABLE IF EXISTS t1, t2, t3"]
+           (-> (drop-table :if-exists :t1 :t2 :t3)
+               sql/format)))))


### PR DESCRIPTION
If the first to :drop-table parameters is :if-exists then prepend IF EXIST to DROP
TABLE. Use the rest of the parameters for the tables in this case.