### PR TITLE
Add ILIKE handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Currently honeysql-postgres supports the following postgres specific clauses:
   - drop column
   - rename column
 - insert-into-as
+- pattern matching (ILIKE and NOT ILIKE)
 
 ## Index
 
@@ -37,6 +38,7 @@ Currently honeysql-postgres supports the following postgres specific clauses:
   - [create table](https://github.com/nilenso/honeysql-postgres#create-table)
   - [drop table](https://github.com/nilenso/honeysql-postgres#drop-table)
   - [alter table](https://github.com/nilenso/honeysql-postgres#alter-table)
+  - [pattern matching](https://github.com/nilenso/honeysql-postgres#pattern-matching)
   - [SQL functions](https://github.com/nilenso/honeysql-postgres#sql-functions)
 - [License](https://github.com/nilenso/honeysql-postgres#license)
 
@@ -159,6 +161,25 @@ use `alter-table` along with `add-column` & `drop-column` to modify table level 
     (psqlh/drop-column :address)
     sql/format)
 => ["ALTER TABLE employees DROP COLUMN address"]
+```
+
+### pattern matching
+The `ilike` and `not-ilike` operators can be used to query data using a pattern matching technique.
+- like
+```clj
+(-> (select :name)
+    (from :products)
+    (where [:ilike :name "%name%"])
+    sql/format)
+=> ["SELECT * FROM products WHERE name ILIKE ?" "%name%"]
+```
+- not-ilike
+```clj
+(-> (select :name)
+    (from :products)
+    (where [:not-ilike :name "%name%"])
+    sql/format)
+=> ["SELECT * FROM products WHERE name NOT ILIKE ?" "%name%"]
 ```
 
 ### SQL functions

--- a/src/honeysql_postgres/format.cljc
+++ b/src/honeysql_postgres/format.cljc
@@ -85,12 +85,16 @@
                       preds)]
     (str "CHECK" pred-string)))
 
+(defmethod fmt/fn-handler "ilike" [_ field value]
+  (str (fmt/to-sql field) " ILIKE "
+       (fmt/to-sql value)))
+
 ;; format-clause multimethods used to format various sql clauses as defined
 
 (defmethod format-clause :on-conflict-constraint [[_ k] _]
   (str "ON CONFLICT ON CONSTRAINT " (-> k
-                                        util/get-first
-                                        sqlf/to-sql)))
+                                       util/get-first
+                                       sqlf/to-sql)))
 
 (defmethod format-clause :on-conflict [[_ ids] _]
   (str "ON CONFLICT " (util/comma-join-args ids)))

--- a/src/honeysql_postgres/format.cljc
+++ b/src/honeysql_postgres/format.cljc
@@ -85,9 +85,13 @@
                       preds)]
     (str "CHECK" pred-string)))
 
-(defmethod fmt/fn-handler "ilike" [_ field value]
-  (str (fmt/to-sql field) " ILIKE "
-       (fmt/to-sql value)))
+(defmethod fn-handler "ilike" [_ field value]
+  (str (sqlf/to-sql field) " ILIKE "
+       (sqlf/to-sql value)))
+
+(defmethod fn-handler "not-ilike" [_ field value]
+  (str (sqlf/to-sql field) " NOT ILIKE "
+       (sqlf/to-sql value)))
 
 ;; format-clause multimethods used to format various sql clauses as defined
 

--- a/test/honeysql_postgres/postgres_test.cljc
+++ b/test/honeysql_postgres/postgres_test.cljc
@@ -199,8 +199,16 @@
 
 (deftest select-where-ilike
   (testing "select from table with ILIKE operator"
-    (is (= ["SELECT * FROM products WHERE name ILIKE ?" "%name%"])
-        (-> (select :*)
-           (from :products)
-           (where [:ilike :name "%name%"])
-           sql/format))))
+    (is (= ["SELECT * FROM products WHERE name ILIKE ?" "%name%"]
+           (-> (select :*)
+              (from :products)
+              (where [:ilike :name "%name%"])
+              sql/format)))))
+
+(deftest select-where-not-ilike
+  (testing "select from table with NOT ILIKE operator"
+    (is (= ["SELECT * FROM products WHERE name NOT ILIKE ?" "%name%"]
+           (-> (select :*)
+              (from :products)
+              (where [:not-ilike :name "%name%"])
+              sql/format)))))

--- a/test/honeysql_postgres/postgres_test.cljc
+++ b/test/honeysql_postgres/postgres_test.cljc
@@ -196,3 +196,11 @@
     (is (= ["DROP TABLE IF EXISTS t1, t2, t3"]
            (-> (drop-table :if-exists :t1 :t2 :t3)
                sql/format)))))
+
+(deftest select-where-ilike
+  (testing "select from table with ILIKE operator"
+    (is (= ["SELECT * FROM products WHERE name ILIKE ?" "%name%"])
+        (-> (select :*)
+           (from :products)
+           (where [:ilike :name "%name%"])
+           sql/format))))


### PR DESCRIPTION
The possibility to query by "ILIKE" is not present  in honeysql (since it's not part of ANSI SQL). But since it is a feature available on PostgreSQL it seemed appropriate to add it here.