### PR TITLE
Update README.md: fixed typo alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ The query creation and usage is exactly the same as honeysql.
 (-> (insert-into :distributors)
     (values [{:did 23 :dname "Foo Distributors"}])
     (psqlh/on-conflict :did)
-    (psqlh/do-update-set! [:dname "EXCLUDED.dname || ' (formerly ' || d.dname || ')'"])
+    (psqlh/do-update-set! [:dname "EXCLUDED.dname || ' (formerly ' || distributors.dname || ')'"])
     sql/format)
 => ["INSERT INTO distributors (did, dname) VALUES (23, ?) ON CONFLICT (did) DO UPDATE SET dname = ?" "Foo Distributors" "EXCLUDED.dname || ' (formerly ' || d.dname || ')'"]
 ```


### PR DESCRIPTION
distributors table was referenced by alias d as in postgresql docs, but this is example without aliases