### PR TITLE
upsert with modify example bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,9 +86,9 @@ The query creation and usage is exactly the same as honeysql.
 (-> (insert-into :distributors)
     (values [{:did 23 :dname "Foo Distributors"}])
     (psqlh/on-conflict :did)
-    (psqlh/do-update-set! [:dname "EXCLUDED.dname || ' (formerly ' || distributors.dname || ')'"])
+    (psqlh/do-update-set! [:dname (sql/call :CONCAT :EXCLUDED.dname " (formerly " :distributors.dname ")")])
     sql/format)
-=> ["INSERT INTO distributors (did, dname) VALUES (23, ?) ON CONFLICT (did) DO UPDATE SET dname = ?" "Foo Distributors" "EXCLUDED.dname || ' (formerly ' || d.dname || ')'"]
+=> ["INSERT INTO distributors (did, dname) VALUES (?, ?) ON CONFLICT (did) DO UPDATE SET dname = CONCAT(EXCLUDED.dname, ?, distributors.dname, ?)" 23 "Foo Distributors" " (formerly " ")"]
 ```
 
 ### insert into with alias


### PR DESCRIPTION
Result of the example
`["INSERT INTO distributors (did, dname) VALUES (23, ?) ON CONFLICT (did) DO UPDATE SET dname = ?" "Foo Distributors" "EXCLUDED.dname || ' (formerly ' || d.dname || ')'"]`
Will make dname set to varchar value which is exactly `"EXCLUDED.dname || ' (formerly ' || d.dname || ')'"` string, without value substitutions and concatenation being called. Need to use `sql/call` with `:CONCAT` (`:||` for some reason not added to `honeysql.format/infix-fns` maybe there is need to extend it in honeysql-postgres?)