### PR TITLE
Fix query-values priority

### DIFF
--- a/src/honeysql_postgres/format.cljc
+++ b/src/honeysql_postgres/format.cljc
@@ -45,7 +45,7 @@
           :offset 210
           :lock 215
           :values 220
-          :query-values 250}
+          :query-values 221}
          custom-additions))
 
 (defn override-default-clause-priority


### PR DESCRIPTION
When used with an upsert clause, query-values was not being rendered
with the correct priority. The provided test fails on master and passes
on this branch. It was previously rendering the SQL as:

```
INSERT INTO distributors (did, dname)
ON CONFLICT ON CONSTRAINT distributors_pkey DO NOTHING
(SELECT ?, ?)
```

which is not valid SQL. The below snippet from psql demonstrates this
not working:

```
muncher=# insert into foo (id) select 1 on conflict do nothing;
INSERT 0 1
muncher=# insert into foo (id) on conflict do nothing (select 1);
ERROR:  syntax error at or near "on"
LINE 1: insert into foo (id) on conflict do nothing (select 1);
```