### PR TITLE
Add support for DISTINCT ON

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,1 +1,1 @@
-{:deps {honeysql {:mvn/version "0.9.4" :exclusions [org.clojure/clojurescript]}}}
+{:deps {honeysql {:git/url "https://github.com/jkk/honeysql" :sha "be203e9086808c47ab7e42520950db0bfd9efcc1" :exclusions [org.clojure/clojurescript]}}}

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nilenso/honeysql-postgres "0.2.5"
+(defproject b-ryan/honeysql-postgres "0.2.6"
   :description "PostgreSQL extension for honeysql"
   :url "https://github.com/nilenso/honeysql-postgres"
   :license {:name "Eclipse Public License"

--- a/src/honeysql_postgres/format.cljc
+++ b/src/honeysql_postgres/format.cljc
@@ -1,6 +1,6 @@
 (ns ^{:doc "Extension of the honeysql format functions specifically for postgreSQL"}
     honeysql-postgres.format
-  (:require [honeysql.format :as sqlf :refer [fn-handler format-clause]] ;; multi-methods
+  (:require [honeysql.format :as sqlf :refer [fn-handler format-clause format-modifiers]] ;; multi-methods
             [honeysql-postgres.util :as util]))
 
 (def ^:private custom-additions
@@ -209,3 +209,6 @@
   (str  "INSERT INTO " (sqlf/to-sql table-name) " AS " (sqlf/to-sql table-alias)))
 
 (override-default-clause-priority)
+
+(defmethod format-modifiers :distinct-on [[_ & fields]]
+  (str "DISTINCT ON(" (sqlf/comma-join (map sqlf/to-sql fields)) ")"))

--- a/test/honeysql_postgres/postgres_test.cljc
+++ b/test/honeysql_postgres/postgres_test.cljc
@@ -8,7 +8,8 @@
                                                          create-table rename-table drop-table
                                                          window create-view over with-columns]]
             [honeysql.helpers :as sqlh :refer [insert-into values where select columns
-                                               from order-by update sset query-values]]
+                                               from order-by update sset query-values
+                                               modifiers]]
             [honeysql.core :as sql]
             [clojure.test :as test :refer [deftest is testing]]))
 
@@ -219,3 +220,11 @@
               (from :products)
               (where [:not-ilike :name "%name%"])
               sql/format)))))
+
+(deftest select-distinct-on
+  (testing "select distinct on"
+    (is (= ["SELECT DISTINCT ON(\"a\", \"b\") \"c\" FROM \"products\" "]
+           (-> (select :c)
+              (from :products)
+              (modifiers :distinct-on :a :b)
+              (sql/format :quoting :ansi))))))


### PR DESCRIPTION
Resolves #31

This uses the new multimethod added to honeysql in
https://github.com/jkk/honeysql/commit/509df1970247954d11baf52ff3897c9440acb394
to add DISTINCT ON support.

Tests are included which cover the behavior.

This commit updates deps.edn to point to the github repo for honeysql
which will obviously have to be changed once honeysql is released.