### PR TITLE
Require honey-sql-postgres.format into honeysql-postgres.helpers so consumers don't have to

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,11 +41,8 @@ This library aims to extend the features of honeysql to support postgres specifi
 ```
 ### REPL
 ```clj
-; Note that `honeysql-postgres.format` and `honeysql-postgres.helpers`
-; must be required into the project for the extended features to work.
 (require '[honeysql.core :as sql]
          '[honeysql.helpers :refer :all]
-         '[honeysql-postgres.format :refer :all]
          '[honeysql-postgres.helpers :as psqlh])
 ```
 

--- a/src/honeysql_postgres/helpers.cljc
+++ b/src/honeysql_postgres/helpers.cljc
@@ -1,6 +1,7 @@
 (ns honeysql-postgres.helpers
   (:refer-clojure :exclude [partition-by])
-  (:require [honeysql.helpers :as sqlh #?(:clj :refer :cljs :refer-macros) [defhelper]]))
+  (:require [honeysql-postgres.format :refer :all]
+            [honeysql.helpers :as sqlh #?(:clj :refer :cljs :refer-macros) [defhelper]]))
 
 ;; Extension of the honeysql helper funcitons for postgreSQL
 

--- a/test/honeysql_postgres/postgres_test.cljc
+++ b/test/honeysql_postgres/postgres_test.cljc
@@ -1,7 +1,6 @@
 (ns honeysql-postgres.postgres-test
   (:refer-clojure :exclude [update partition-by])
-  (:require [honeysql-postgres.format :as sqlpf]
-            [honeysql-postgres.helpers :as sqlph :refer [upsert on-conflict do-nothing on-conflict-constraint
+  (:require [honeysql-postgres.helpers :as sqlph :refer [upsert on-conflict do-nothing on-conflict-constraint
                                                          returning do-update-set do-update-set!
                                                          alter-table rename-column drop-column
                                                          add-column partition-by insert-into-as


### PR DESCRIPTION
For: https://github.com/nilenso/honeysql-postgres/issues/27