### PR TITLE
Add create / drop extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,8 +149,8 @@ use `alter-table` along with `add-column` & `drop-column` to modify table level 
 `create-extension` can be used to create extensions with a given keyword.
 ```clj
 (-> (create-extension :uuid-ossp :if-not-exists? true)
-               (sql/format :allow-dashed-names? true
-                           :quoting :ansi))
+    (sql/format :allow-dashed-names? true
+                :quoting :ansi))
 
 => ["CREATE EXTENSION IF NOT EXISTS \"uuid-ossp\""]
 ```
@@ -158,7 +158,9 @@ use `alter-table` along with `add-column` & `drop-column` to modify table level 
 ### drop-extension
 `drop-extension` is used to drop extensions.
 ```clj
-(drop-extension "uuid-ossp")
+(-> (drop-extension :uuid-ossp)
+    (sql/format :allow-dashed-names? true
+                :quoting :ansi))
 => ["DROP EXTENSION \"uuid-ossp\""]
 ```
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ This library aims to extend the features of honeysql to support postgres specifi
   - [create table](#create-table)
   - [drop table](#drop-table)
   - [alter table](#alter-table)
+  - [create extension](#create-extension)
+  - [drop extension](#drop-extension)
   - [pattern matching](#pattern-matching)
   - [except](#except)
   - [SQL functions](#sql-functions)
@@ -141,6 +143,23 @@ use `alter-table` along with `add-column` & `drop-column` to modify table level 
     (psqlh/drop-column :address)
     sql/format)
 => ["ALTER TABLE employees DROP COLUMN address"]
+```
+
+### create-extension
+`create-extension` can be used to create extensions with a given keyword.
+```clj
+(-> (create-extension :uuid-ossp :if-not-exists? true)
+               (sql/format :allow-dashed-names? true
+                           :quoting :ansi))
+
+=> ["CREATE EXTENSION IF NOT EXISTS \"uuid-ossp\""]
+```
+
+### drop-extension
+`drop-extension` is used to drop extensions.
+```clj
+(drop-extension "uuid-ossp")
+=> ["DROP EXTENSION \"uuid-ossp\""]
 ```
 
 ### pattern matching

--- a/src/honeysql_postgres/format.cljc
+++ b/src/honeysql_postgres/format.cljc
@@ -7,6 +7,8 @@
 (def ^:private custom-additions
   {:create-table 10
    :drop-table 10
+   :create-extension 10
+   :drop-extension 10
    :alter-table 20
    :add-column 30
    :drop-column 40
@@ -223,3 +225,16 @@
 
 (defmethod format-modifiers :distinct-on [[_ & fields]]
   (str "DISTINCT ON(" (sqlf/comma-join (map sqlf/to-sql fields)) ")"))
+
+(defmethod sqlf/format-clause :drop-extension [[_ [extension-name]] _]
+  (str "DROP EXTENSION "
+       (-> extension-name
+           util/get-first
+           sqlf/to-sql)))
+
+(defmethod format-clause :create-extension [[_ [ extension-name if-not-exists]] _]
+  (str "CREATE EXTENSION "
+       (when if-not-exists "IF NOT EXISTS ")
+       (-> extension-name
+           util/get-first
+           sqlf/to-sql)))

--- a/src/honeysql_postgres/helpers.cljc
+++ b/src/honeysql_postgres/helpers.cljc
@@ -67,3 +67,9 @@
 
 (defhelper insert-into-as [m fields]
   (assoc m :insert-into-as (sqlh/collify fields)))
+
+(defhelper create-extension [m extension-name]
+  (assoc m :create-extension (sqlh/collify extension-name)))
+
+(defhelper drop-extension [m extension-name]
+  (assoc m :drop-extension (sqlh/collify extension-name)))

--- a/test/honeysql_postgres/postgres_test.cljc
+++ b/test/honeysql_postgres/postgres_test.cljc
@@ -5,7 +5,8 @@
                                                          alter-table rename-column drop-column
                                                          add-column partition-by insert-into-as
                                                          create-table rename-table drop-table
-                                                         window create-view over with-columns]]
+                                                         window create-view over with-columns
+                                                         create-extension drop-extension]]
             [honeysql.helpers :as sqlh :refer [insert-into values where select columns
                                                from order-by update sset query-values
                                                modifiers]]
@@ -257,3 +258,22 @@
                (from :products)
                (modifiers :distinct-on :a :b)
                (sql/format :quoting :ansi))))))
+
+(deftest create-extension-test
+  (testing "create extension"
+    (is (= ["CREATE EXTENSION \"uuid-ossp\""]
+           (-> (create-extension :uuid-ossp)
+               (sql/format :allow-dashed-names? true
+                           :quoting :ansi)))))
+  (testing "create extension if not exists"
+    (is (= ["CREATE EXTENSION IF NOT EXISTS \"uuid-ossp\""]
+           (-> (create-extension :uuid-ossp :if-not-exists? true)
+               (sql/format :allow-dashed-names? true
+                           :quoting :ansi))))))
+
+(deftest drop-extension-test
+  (testing "create extension"
+    (is (= ["DROP EXTENSION \"uuid-ossp\""]
+           (-> (drop-extension :uuid-ossp)
+               (sql/format :allow-dashed-names? true
+                           :quoting :ansi))))))


### PR DESCRIPTION
Adds the create / drop extension statements which seem to be missing.
https://www.postgresql.org/docs/9.1/sql-createextension.html
https://www.postgresql.org/docs/9.1/sql-dropextension.html