### PR TITLE
Add `constraints` format-clause with support for UNIQUE and PRIMARY KEY

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,13 @@ The following are the SQL functions added in `honeysql-postgres`
 
 (sql/format (sql/call :primary-key :arg1 :arg2))
 => ["PRIMARY KEY(arg1, arg2)"]
+
+(-> (psqlh/create-table :table)
+    (psqlh/with-columns [[:column_1 :integer]
+                         [:column_2 :text]])
+    (psqlh/constraints  [[:primary-key [:column_1]]])
+    sql/format)
+=> ["CREATE TABLE table  (column_1 integer, column_2 text, PRIMARY KEY(column_1))"]
 ```
 - `unique`
 ```clojure
@@ -263,6 +270,13 @@ The following are the SQL functions added in `honeysql-postgres`
 
 (sql/format (sql/call :unique :arg1 :arg2))
 => ["UNIQUE(arg1, arg2)"]
+
+(-> (psqlh/create-table :table)
+    (psqlh/with-columns [[:column_1 :integer]
+                         [:column_2 :text]])
+    (psqlh/constraints  [[:unique [:column_2]]])
+    sql/format)
+=> ["CREATE TABLE table  (column_1 integer, column_2 text, UNIQUE(column_2))"]
 ```
 - `foreign-key`
 ```clojure

--- a/src/honeysql_postgres/format.cljc
+++ b/src/honeysql_postgres/format.cljc
@@ -17,6 +17,8 @@
    :within-group 55
    :over 55
    :insert-into-as 60
+   :with-columns 70
+   :constraints 75
    :partition-by 165
    :window 195
    :upsert 225
@@ -161,11 +163,39 @@
            util/get-first
            sqlf/to-sql)))
 
-(defmethod format-clause :with-columns [[_ columns] _]
-  (sqlf/paren-wrap (->> columns
-                        util/get-first
-                        (map #(sqlf/space-join (map sqlf/to-sql %)))
-                        sqlf/comma-join)))
+(def ^:private constraints-format-map
+  {:primary-key "PRIMARY KEY"
+   :unique      "UNIQUE"})
+
+(defn- format-constraint-clause
+  [[constraint-type constraint-args]]
+  (when (contains? constraints-format-map constraint-type)
+    (str (get constraints-format-map constraint-type)
+         (sqlf/paren-wrap (->> constraint-args
+                               (map sqlf/to-sql)
+                               sqlf/comma-join)))))
+
+(defn- format-columns-clause
+  [columns]
+  (->> columns
+       util/get-first
+       (map #(sqlf/space-join (map sqlf/to-sql %)))
+       sqlf/comma-join))
+
+(defmethod format-clause :with-columns [[_ columns] complete-sql-map]
+  (when-not (seq (:constraints complete-sql-map))
+    (sqlf/paren-wrap (format-columns-clause columns))))
+
+(defmethod format-clause :constraints [[_ [constraints]] complete-sql-map]
+  (let [columns (:with-columns complete-sql-map)
+        constraints (filter (fn [[constraint-type _]]
+                              (contains? constraints-format-map constraint-type)) constraints)]
+    (sqlf/paren-wrap
+     (str (when (seq columns)
+            (format-columns-clause columns))
+          (when (seq constraints)
+            (str ", "
+                 (sqlf/comma-join (map format-constraint-clause constraints))))))))
 
 (defmethod format-clause :drop-table [[_ params] _]
   (let [[if-exists & others] params

--- a/src/honeysql_postgres/helpers.cljc
+++ b/src/honeysql_postgres/helpers.cljc
@@ -42,6 +42,9 @@
 (defhelper with-columns [m args]
   (assoc m :with-columns args))
 
+(defhelper constraints [m args]
+  (assoc m :constraints args))
+
 (defhelper drop-table [m tablenames]
   (assoc m :drop-table (sqlh/collify tablenames)))
 

--- a/test/honeysql_postgres/postgres_test.cljc
+++ b/test/honeysql_postgres/postgres_test.cljc
@@ -8,6 +8,7 @@
              :refer
              [add-column
               alter-table
+              constraints
               create-extension
               create-table
               create-view
@@ -191,6 +192,43 @@
                               [:price :numeric (sql/call :check [:> :price 0])]
                               [:discounted_price :numeric]
                               [(sql/call :check [:> :discounted_price 0] [:> :price :discounted_price])]])
+               sql/format)))))
+
+(deftest constraints-test
+  (testing "creating table with unique constraint on multiple columns"
+    (is (= ["CREATE TABLE products  (product_no integer, name text, product_sku integer, UNIQUE(product_no, product_sku))"]
+           (-> (create-table :products)
+               (with-columns [[:product_no :integer]
+                              [:name :text]
+                              [:product_sku :integer]])
+               (constraints [[:unique [:product_no :product_sku]]])
+               sql/format))))
+  (testing "creating table with primary key constraint on single column"
+    (is (= ["CREATE TABLE products  (product_no integer, name text, product_sku integer, PRIMARY KEY(product_no))"]
+           (-> (create-table :products)
+               (with-columns [[:product_no :integer]
+                              [:name :text]
+                              [:product_sku :integer]])
+               (constraints [[:primary-key [:product_no]]])
+               sql/format))))
+  (testing "creating table with primary key and unique constraints"
+    (is (= ["CREATE TABLE products  (product_no integer, name text, product_sku integer, UNIQUE(product_no, product_sku), PRIMARY KEY(product_no))"]
+           (-> (create-table :products)
+               (with-columns [[:product_no :integer]
+                              [:name :text]
+                              [:product_sku :integer]])
+               (constraints [[:unique [:product_no :product_sku]]
+                             [:primary-key [:product_no]]])
+               sql/format))))
+  (testing "creating table with invalid/unsupported constraints does not produce incorrect SQL statement"
+    (is (= ["CREATE TABLE products  (product_no integer, name text, product_sku integer, PRIMARY KEY(product_no))"]
+           (-> (create-table :products)
+               (with-columns [[:product_no :integer]
+                              [:name :text]
+                              [:product_sku :integer]])
+               (constraints [[:unique-constraint [:product_no]] ;; incorrect constraint-type
+                             [:primary-key [:product_no]]
+                             [:not-null [:name]]])              ;; unsupported constraint-type
                sql/format)))))
 
 (deftest over-test


### PR DESCRIPTION
Related issue - #15

- new constraints `defhelper` which adds a top-level `:constraints` key to the complete-sql-map
- moved format-clause for `:with-columns` into its own function so that it can be reused in the `constraints` format-clause method as well
- when constraints aren't present, the formatter uses `:with-columns` to construct the SQL string
- when constraints are present, the formatter uses `:constraints` to construct the columns and constraints string wrapped in the same set of parens 