### PR TITLE
add join-lateral && case-when clauses

### DIFF
--- a/src/honeysql_postgres/format.cljc
+++ b/src/honeysql_postgres/format.cljc
@@ -17,6 +17,8 @@
    :within-group 55
    :over 55
    :insert-into-as 60
+   :join-lateral 153
+   :left-join-lateral 154
    :partition-by 165
    :window 195
    :upsert 225
@@ -267,3 +269,40 @@
        (-> extension-name
            util/get-first
            sqlf/to-sql)))
+
+(defn- format-join [type table pred]
+  (str (when type
+         (str (string/upper-case (name type)) " "))
+       "JOIN LATERAL " (sqlf/to-sql table)
+       (when (some? pred)
+         (str " ON " (sqlf/format-predicate* pred)))))
+
+(defn- make-join [type join-groups]
+  (sqlf/space-join (map #(apply format-join type %)
+                        (partition 2 join-groups))))
+
+(defmethod format-clause :join-lateral [[_ join-groups] _]
+  (make-join :inner join-groups))
+
+(defmethod format-clause :left-join-lateral [[_ join-groups] _]
+  (make-join :left join-groups))
+
+(defn- format-case-preds [pred-thens]
+  (map (fn [[pred then]]
+         (str "WHEN " (sqlf/format-predicate* pred)
+              " THEN " (sqlf/to-sql then)))
+       (partition 2 pred-thens)))
+
+(defn- format-branches
+  [branches]
+  (str "CASE " (sqlf/space-join branches) " END"))
+
+(defmethod format-clause :case-when
+  [[_ pred-thens] _]
+  (format-branches (format-case-preds pred-thens)))
+
+(defmethod format-clause :case-when-else
+  [[_ pred-thens] _]
+  (let [else (last pred-thens)]
+    (format-branches (concat (format-case-preds (drop-last pred-thens))
+                             [(str "ELSE " (sqlf/to-sql else))]))))

--- a/src/honeysql_postgres/format.cljc
+++ b/src/honeysql_postgres/format.cljc
@@ -304,5 +304,5 @@
 (defmethod format-clause :case-when-else
   [[_ pred-thens] _]
   (let [else (last pred-thens)]
-    (format-branches (concat (format-case-preds (drop-last pred-thens))
+    (format-branches (concat (vec (format-case-preds (drop-last pred-thens)))
                              [(str "ELSE " (sqlf/to-sql else))]))))

--- a/src/honeysql_postgres/helpers.cljc
+++ b/src/honeysql_postgres/helpers.cljc
@@ -80,3 +80,19 @@
 
 (defhelper drop-extension [m extension-name]
   (assoc m :drop-extension (sqlh/collify extension-name)))
+
+(defhelper join-lateral
+  [m clauses]
+  (assoc m :join-lateral clauses))
+
+(defhelper left-join-lateral
+  [m clauses]
+  (assoc m :left-join-lateral clauses))
+
+(defhelper case-when
+  [m clauses]
+  (assoc m :case-when clauses))
+
+(defhelper case-when-else
+  [m clauses]
+  (assoc m :case-when-else clauses))

--- a/test/honeysql_postgres/postgres_test.cljc
+++ b/test/honeysql_postgres/postgres_test.cljc
@@ -340,34 +340,34 @@
                            :quoting :ansi))))))
 
 (deftest case-when-test
-  (is (= ["CASE WHEN x = 1 THEN x WHEN x > 1 THEN y END"]
-         (-> (case-when [:= :x (sql/inline 1)] :x
-                        [:> :x (sql/inline 1)] :y)
+  (is (= ["CASE WHEN x = ? THEN x WHEN x > ? THEN y END" 1 2]
+         (-> (case-when [:= :x 1] :x
+                        [:> :x 2] :y)
              sql/format))))
 
 (deftest case-when-else-test
-  (is (= ["CASE WHEN x = 1 THEN x WHEN x > 1 THEN y ELSE z END"]
-         (-> (case-when-else [:= :x (sql/inline 1)] :x
-                             [:> :x (sql/inline 1)] :y
-                             :z)
+  (is (= ["CASE WHEN x = ? THEN x WHEN x > ? THEN y ELSE ? END" 1 2 5]
+         (-> (case-when-else [:= :x 1] :x
+                             [:> :x 2] :y
+                             5)
              sql/format))))
 
 (deftest join-lateral-test
-  (is (= ["SELECT count(x3), count(x0) FROM x_values INNER JOIN LATERAL (SELECT (CASE WHEN x > 3 THEN x END) AS x3, (CASE WHEN x > 0 THEN x END) AS x0) z ON true"]
+  (is (= ["SELECT count(x3), count(x0) FROM x_values INNER JOIN LATERAL (SELECT (CASE WHEN x > ? THEN x END) AS x3, (CASE WHEN x > ? THEN x END) AS x0) z ON true" 3 0]
          (-> (select :%count.x3
                      :%count.x0)
              (from :x-values)
              (join-lateral [(select
-                             [(case-when [:> :x (sql/inline 3)] :x) :x3]
-                             [(case-when [:> :x (sql/inline 0)] :x) :x0]) :z] :true)
+                             [(case-when [:> :x 3] :x) :x3]
+                             [(case-when [:> :x 0] :x) :x0]) :z] :true)
              sql/format))))
 
 (deftest left-join-lateral-test
-  (is (= ["SELECT count(x3), count(x0) FROM x_values LEFT JOIN LATERAL (SELECT (CASE WHEN x > 3 THEN x END) AS x3, (CASE WHEN x > 0 THEN x END) AS x0) z ON true"]
+  (is (= ["SELECT count(x3), count(x0) FROM x_values LEFT JOIN LATERAL (SELECT (CASE WHEN x > ? THEN x END) AS x3, (CASE WHEN x > ? THEN x END) AS x0) z ON true" 3 0]
          (-> (select :%count.x3
                      :%count.x0)
              (from :x-values)
              (left-join-lateral [(select
-                                  [(case-when [:> :x (sql/inline 3)] :x) :x3]
-                                  [(case-when [:> :x (sql/inline 0)] :x) :x0]) :z] :true)
+                                  [(case-when [:> :x 3] :x) :x3]
+                                  [(case-when [:> :x 0] :x) :x0]) :z] :true)
              sql/format))))

--- a/test/honeysql_postgres/postgres_test.cljc
+++ b/test/honeysql_postgres/postgres_test.cljc
@@ -8,6 +8,8 @@
              :refer
              [add-column
               alter-table
+              case-when
+              case-when-else
               create-extension
               create-table
               create-view
@@ -19,6 +21,8 @@
               drop-table
               filter
               insert-into-as
+              join-lateral
+              left-join-lateral
               on-conflict
               on-conflict-constraint
               over
@@ -334,3 +338,36 @@
            (-> (drop-extension :uuid-ossp)
                (sql/format :allow-dashed-names? true
                            :quoting :ansi))))))
+
+(deftest case-when-test
+  (is (= ["CASE WHEN x = 1 THEN x WHEN x > 1 THEN y END"]
+         (-> (case-when [:= :x (sql/inline 1)] :x
+                        [:> :x (sql/inline 1)] :y)
+             sql/format))))
+
+(deftest case-when-else-test
+  (is (= ["CASE WHEN x = 1 THEN x WHEN x > 1 THEN y ELSE z END"]
+         (-> (case-when-else [:= :x (sql/inline 1)] :x
+                             [:> :x (sql/inline 1)] :y
+                             :z)
+             sql/format))))
+
+(deftest join-lateral-test
+  (is (= ["SELECT count(x3), count(x0) FROM x_values INNER JOIN LATERAL (SELECT (CASE WHEN x > 3 THEN x END) AS x3, (CASE WHEN x > 0 THEN x END) AS x0) z ON true"]
+         (-> (select :%count.x3
+                     :%count.x0)
+             (from :x-values)
+             (join-lateral [(select
+                             [(case-when [:> :x (sql/inline 3)] :x) :x3]
+                             [(case-when [:> :x (sql/inline 0)] :x) :x0]) :z] :true)
+             sql/format))))
+
+(deftest left-join-lateral-test
+  (is (= ["SELECT count(x3), count(x0) FROM x_values LEFT JOIN LATERAL (SELECT (CASE WHEN x > 3 THEN x END) AS x3, (CASE WHEN x > 0 THEN x END) AS x0) z ON true"]
+         (-> (select :%count.x3
+                     :%count.x0)
+             (from :x-values)
+             (left-join-lateral [(select
+                                  [(case-when [:> :x (sql/inline 3)] :x) :x3]
+                                  [(case-when [:> :x (sql/inline 0)] :x) :x0]) :z] :true)
+             sql/format))))


### PR DESCRIPTION
Sometimes we need to use the `JOIN LATERAL` construction to optimize our queries. But such clause not so useful without `CASE WHEN THEN` expression, so I've added both ones.